### PR TITLE
further JCR2 fixing

### DIFF
--- a/brix-core/src/main/java/brix/Brix.java
+++ b/brix-core/src/main/java/brix/Brix.java
@@ -14,29 +14,10 @@
 
 package brix;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-
-import org.apache.jackrabbit.core.WorkspaceImpl;
-import org.apache.wicket.AbstractRestartResponseException;
-import org.apache.wicket.Application;
-import org.apache.wicket.IRequestTarget;
-import org.apache.wicket.MetaDataKey;
-import org.apache.wicket.Page;
-import org.apache.wicket.RequestCycle;
-import org.apache.wicket.RestartResponseException;
-import org.apache.wicket.protocol.http.WebApplication;
-import org.apache.wicket.request.target.component.IPageRequestTarget;
-
 import brix.auth.Action;
+import brix.auth.Action.Context;
 import brix.auth.AuthorizationStrategy;
 import brix.auth.ViewWorkspaceAction;
-import brix.auth.Action.Context;
 import brix.config.BrixConfig;
 import brix.exception.BrixException;
 import brix.jcr.JcrNodeWrapperFactory;
@@ -44,7 +25,6 @@ import brix.jcr.RepositoryInitializer;
 import brix.jcr.SessionBehavior;
 import brix.jcr.api.JcrNode;
 import brix.jcr.api.JcrSession;
-import brix.jcr.exception.JcrException;
 import brix.jcr.wrapper.BrixNode;
 import brix.plugin.site.SitePlugin;
 import brix.plugin.site.SiteRootNode;
@@ -57,24 +37,29 @@ import brix.plugin.site.page.tile.Tile;
 import brix.plugin.site.webdav.RulesNode;
 import brix.registry.ExtensionPointRegistry;
 import brix.web.BrixExtensionStringResourceLoader;
-import brix.web.nodepage.BrixNodePageUrlCodingStrategy;
-import brix.web.nodepage.BrixNodeRequestTarget;
-import brix.web.nodepage.BrixNodeWebPage;
-import brix.web.nodepage.BrixPageParameters;
-import brix.web.nodepage.ForbiddenPage;
-import brix.web.nodepage.PageParametersAwareEnabler;
+import brix.web.nodepage.*;
 import brix.web.tile.pagetile.PageTile;
 import brix.workspace.Workspace;
 import brix.workspace.WorkspaceManager;
+import org.apache.wicket.*;
+import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.request.target.component.IPageRequestTarget;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * TODO doc
- * 
+ *
  * Before brix can be used {@link #initRepository()} method should be called.
- * 
- * 
+ *
+ *
  * @author igor.vaynberg
- * 
+ *
  */
 public abstract class Brix
 {
@@ -163,7 +148,7 @@ public abstract class Brix
 
 	/**
 	 * Performs any {@link WebApplication} specific initialization
-	 * 
+	 *
 	 * @param application
 	 */
 	public void attachTo(WebApplication application)
@@ -203,16 +188,7 @@ public abstract class Brix
 	 */
 	protected void createWorkspace(JcrSession session, String name)
 	{
-		// TODO: Decouple this from BRIX
-		WorkspaceImpl workspace = (WorkspaceImpl)session.getWorkspace().getDelegate();
-		try
-		{
-			workspace.createWorkspace(name);
-		}
-		catch (RepositoryException e)
-		{
-			throw new JcrException(e);
-		}
+        session.getWorkspace().createWorkspace(name);
 	}
 
 	public void clone(JcrSession src, JcrSession dest)
@@ -250,13 +226,13 @@ public abstract class Brix
 	 * public void publish(String workspace, String targetState, SessionProvider
 	 * sessionProvider) { String dest = getWorkspaceNameForState(workspace,
 	 * targetState);
-	 * 
+	 *
 	 * if (workspace.equals(dest) == false) { List<String> workspaces =
 	 * getAvailableWorkspaces(); if (workspaces.contains(dest) == false) {
 	 * createWorkspace(sessionProvider.getJcrSession(null), dest); }
-	 * 
+	 *
 	 * cleanWorkspace(BrixRequestCycle.Locator.getSession(dest));
-	 * 
+	 *
 	 * cloneWorkspace(BrixRequestCycle.Locator.getSession(workspace),
 	 * BrixRequestCycle.Locator .getSession(dest)); } }
 	 */
@@ -305,7 +281,7 @@ public abstract class Brix
 		}
 		catch (RepositoryException e)
 		{
-			throw new RuntimeException("Couldn't init jackrabbit repository", e);
+			throw new RuntimeException("Couldn't initialize repository", e);
 		}
 
 		for (Workspace w : getWorkspaceManager().getWorkspaces())
@@ -391,10 +367,10 @@ public abstract class Brix
 	 * Constructs a URL to the current page. This method can only be called
 	 * within an active wicket request because it relies on the
 	 * {@link RequestCycle} threadlocal.
-	 * 
+	 *
 	 * @throws BrixException
 	 *             if the current request was not for a brix page
-	 * 
+	 *
 	 * @return url to the current brix page
 	 */
 	public static String urlForCurrentPage()
@@ -407,13 +383,13 @@ public abstract class Brix
 	 * Constructs a URL to the current page. This method can only be called
 	 * within an active wicket request because it relies on the
 	 * {@link RequestCycle} threadlocal.
-	 * 
+	 *
 	 * @param params
 	 *            parameters to be encoded into the url
-	 * 
+	 *
 	 * @throws BrixException
 	 *             if the current request was not for a brix page
-	 * 
+	 *
 	 * @return url to the current brix page
 	 */
 	public static String urlForCurrentPage(BrixPageParameters params)
@@ -427,10 +403,10 @@ public abstract class Brix
 	/**
 	 * Returns current brix page being processed. Must only be called within a
 	 * wicket request.
-	 * 
+	 *
 	 * @throws BrixException
 	 *             if current request was not to a brix page
-	 * 
+	 *
 	 * @return brix page
 	 */
 	private static BrixNodeWebPage getCurrentPage()

--- a/brix-core/src/main/java/brix/jcr/Jcr2ClusteredWorkspaceManager.java
+++ b/brix-core/src/main/java/brix/jcr/Jcr2ClusteredWorkspaceManager.java
@@ -15,23 +15,23 @@
 package brix.jcr;
 
 
-import java.util.Arrays;
-import java.util.List;
-
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-
 import brix.workspace.AbstractClusteredWorkspaceManager;
 import brix.workspace.JcrException;
 import brix.workspace.WorkspaceManager;
 
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import java.util.Arrays;
+import java.util.List;
+
 /**
- * Jackrabbit specific implementation of {@link WorkspaceManager}
+ * JCR2 specific implementation of {@link WorkspaceManager}
  * 
  * @author igor.vaynberg
+ * @author kbachl
  * 
  */
-public class JackrabbitClusteredWorkspaceManager extends AbstractClusteredWorkspaceManager
+public class Jcr2ClusteredWorkspaceManager extends AbstractClusteredWorkspaceManager
 {
 
     private final JcrSessionFactory sf;
@@ -42,7 +42,7 @@ public class JackrabbitClusteredWorkspaceManager extends AbstractClusteredWorksp
      * @param sf
      *            session factory that will be used to feed workspace manager sessions
      */
-    public JackrabbitClusteredWorkspaceManager(JcrSessionFactory sf)
+    public Jcr2ClusteredWorkspaceManager(JcrSessionFactory sf)
     {
         super();
         this.sf = sf;
@@ -55,9 +55,7 @@ public class JackrabbitClusteredWorkspaceManager extends AbstractClusteredWorksp
         Session session = createSession(null);
         try
         {
-        	org.apache.jackrabbit.core.WorkspaceImpl workspace = (org.apache.jackrabbit.core.WorkspaceImpl) session
-					.getWorkspace();
-            workspace.createWorkspace(workspaceName);
+        	session.getWorkspace().createWorkspace(workspaceName);
         }
         catch (RepositoryException e)
         {

--- a/brix-core/src/main/java/brix/jcr/Jcr2WorkspaceManager.java
+++ b/brix-core/src/main/java/brix/jcr/Jcr2WorkspaceManager.java
@@ -15,23 +15,23 @@
 package brix.jcr;
 
 
-import java.util.Arrays;
-import java.util.List;
-
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-
 import brix.workspace.AbstractSimpleWorkspaceManager;
 import brix.workspace.JcrException;
 import brix.workspace.WorkspaceManager;
 
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import java.util.Arrays;
+import java.util.List;
+
 /**
- * Jackrabbit specific implementation of {@link WorkspaceManager}
+ * JCR2 specific implementation of {@link WorkspaceManager}
  * 
  * @author igor.vaynberg
+ * @author kbachl
  * 
  */
-public class JackrabbitWorkspaceManager extends AbstractSimpleWorkspaceManager
+public class Jcr2WorkspaceManager extends AbstractSimpleWorkspaceManager
 {
 
     private final JcrSessionFactory sf;
@@ -42,7 +42,7 @@ public class JackrabbitWorkspaceManager extends AbstractSimpleWorkspaceManager
      * @param sf
      *            session factory that will be used to feed workspace manager sessions
      */
-    public JackrabbitWorkspaceManager(JcrSessionFactory sf)
+    public Jcr2WorkspaceManager(JcrSessionFactory sf)
     {
         super();
         this.sf = sf;
@@ -55,9 +55,7 @@ public class JackrabbitWorkspaceManager extends AbstractSimpleWorkspaceManager
         Session session = createSession(null);
         try
         {
-        	org.apache.jackrabbit.core.WorkspaceImpl workspace = (org.apache.jackrabbit.core.WorkspaceImpl) session
-					.getWorkspace();
-            workspace.createWorkspace(workspaceName);
+            session.getWorkspace().createWorkspace(workspaceName);
         }
         catch (RepositoryException e)
         {

--- a/brix-core/src/main/java/brix/util/JcrUtils.java
+++ b/brix-core/src/main/java/brix/util/JcrUtils.java
@@ -14,22 +14,20 @@
 
 package brix.util;
 
+import brix.jcr.Jcr2WorkspaceManager;
+import brix.jcr.JcrSessionFactory;
+import brix.workspace.WorkspaceManager;
+import brix.workspace.rmi.ClientWorkspaceManager;
+import org.apache.jackrabbit.core.RepositoryImpl;
+import org.apache.jackrabbit.core.config.RepositoryConfig;
+import org.apache.wicket.util.file.File;
+import org.apache.wicket.util.io.Streams;
+
+import javax.jcr.Repository;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-
-import javax.jcr.Repository;
-
-import org.apache.jackrabbit.core.RepositoryImpl;
-import org.apache.jackrabbit.core.config.RepositoryConfig;
-import org.apache.wicket.util.file.File;
-
-import brix.jcr.JackrabbitWorkspaceManager;
-import brix.jcr.JcrSessionFactory;
-import brix.workspace.WorkspaceManager;
-import brix.workspace.rmi.ClientWorkspaceManager;
-import org.apache.wicket.util.io.Streams;
 
 /**
  * Jcr and Jackrabbit related utilities
@@ -53,7 +51,7 @@ public class JcrUtils
      * <code>url</code> is left blank, a local workspace manager will be created.
      * 
      * @param url
-     * @param brix
+     * @param sessionFactory
      * @return
      */
     public static WorkspaceManager createWorkspaceManager(String url,
@@ -62,7 +60,7 @@ public class JcrUtils
         if (url == null || url.trim().length() == 0)
         {
             // create workspace manager for a file system repository
-            JackrabbitWorkspaceManager mgr = new JackrabbitWorkspaceManager(sessionFactory);
+            Jcr2WorkspaceManager mgr = new Jcr2WorkspaceManager(sessionFactory);
             mgr.initialize();
             return mgr;
         }
@@ -129,6 +127,7 @@ public class JcrUtils
                 copyClassResourceToFile("/brix/demo/repository.xml", cfg);
             }
 
+            //TODO: try to clean from Jackrabbit dependency
             InputStream configStream = new FileInputStream(cfg);
             RepositoryConfig config = RepositoryConfig.create(configStream, home.getAbsolutePath());
             return RepositoryImpl.create(config);
@@ -154,6 +153,7 @@ public class JcrUtils
         try
         {
             JcrUtils.class.getClassLoader().loadClass("org.apache.jackrabbit.rmi.client.ClientRepositoryFactory");
+
             return RmiRepositoryFactory.getRmiRepository(url);
         }
         catch (Exception e)

--- a/brix-core/src/main/java/brix/util/RmiRepositoryFactory.java
+++ b/brix-core/src/main/java/brix/util/RmiRepositoryFactory.java
@@ -14,8 +14,8 @@
 
 package brix.util;
 
+import org.apache.jackrabbit.rmi.client.ClientAdapterFactory;
 import org.apache.jackrabbit.rmi.client.ClientRepositoryFactory;
-import org.apache.jackrabbit.rmi.jackrabbit.JackrabbitClientAdapterFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,8 +36,7 @@ public class RmiRepositoryFactory {
 
 
     static Repository getRmiRepository(String url) throws MalformedURLException, NotBoundException, RemoteException {
-        ClientRepositoryFactory factory = new ClientRepositoryFactory(new JackrabbitClientAdapterFactory());
-        Repository repository = factory.getRepository(url);
-        return repository;
+        ClientRepositoryFactory factory = new ClientRepositoryFactory(new ClientAdapterFactory());
+        return factory.getRepository(url);
     }
 }

--- a/brix-core/src/main/java/brix/web/BrixUrlCodingStrategy.java
+++ b/brix-core/src/main/java/brix/web/BrixUrlCodingStrategy.java
@@ -17,17 +17,16 @@
  */
 package brix.web;
 
+import brix.BrixNodeModel;
+import brix.Path;
 import brix.jcr.exception.JcrException;
+import brix.jcr.wrapper.BrixNode;
+import brix.plugin.site.SitePlugin;
+import brix.web.nodepage.BrixNodePageUrlCodingStrategy;
 import org.apache.jackrabbit.spi.commons.conversion.MalformedPathException;
 import org.apache.wicket.IRequestTarget;
 import org.apache.wicket.request.RequestParameters;
 import org.apache.wicket.request.target.coding.IRequestTargetUrlCodingStrategy;
-
-import brix.BrixNodeModel;
-import brix.Path;
-import brix.jcr.wrapper.BrixNode;
-import brix.plugin.site.SitePlugin;
-import brix.web.nodepage.BrixNodePageUrlCodingStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,6 +124,7 @@ public class BrixUrlCodingStrategy implements IRequestTargetUrlCodingStrategy
             while (iter.getCause() != null) {
                 iter = iter.getCause();
             }
+            //TODO: shall we relly rely on Jackrabbit implementation for this??? - truoble is that SPI is not covered by JCR2 intentionally
             if (iter instanceof MalformedPathException) {
                 logger.info("JcrException caught due to incorrect url",e);
             } else {


### PR DESCRIPTION
Hi,

was able to get rid of several jackrabbit occurencies and replace them with default JCR2; Best is that we now have a Jcr2WorkspaceManager and don't rely on Jackrabbit for this anymore.
What currently is a trouble is fact that JCR2 didn't go for SPI as they intentionally left it out, meaning there is no easy path to completely kick out jackrabbit from brix. 
