### PR TITLE
small bug fix

### DIFF
--- a/brix-core/src/main/java/org/brixcms/plugin/site/resource/ResourceNodeHandler.java
+++ b/brix-core/src/main/java/org/brixcms/plugin/site/resource/ResourceNodeHandler.java
@@ -100,6 +100,7 @@ public class ResourceNodeHandler implements IRequestHandler {
 			String fileName = node.getName();
 			long length = node.getContentLength();
 			HttpServletResponse httpServletResponse = (HttpServletResponse) response.getContainerResponse();
+            httpServletResponse.setContentType(node.getMimeType());
 			InputStream stream = node.getDataAsStream();
 
 			new Streamer(length, stream, fileName, save, r, httpServletResponse).stream();


### PR DESCRIPTION
ResourceNodeHandler didn't stream mime type which caused not loading css in IE9
