### PR TITLE
Index work 

### DIFF
--- a/brix-core/src/main/java/org/brixcms/config/PrefixUriMapper.java
+++ b/brix-core/src/main/java/org/brixcms/config/PrefixUriMapper.java
@@ -16,6 +16,7 @@ package org.brixcms.config;
 
 import org.brixcms.Brix;
 import org.brixcms.Path;
+import org.brixcms.plugin.site.SitePlugin;
 
 /**
  * Uri mapper that mounts cms urls on a certain prefix. Eg <code>new PrefixUriMapper(new Path("/docs/cms"))</code> will
@@ -64,6 +65,13 @@ public abstract class PrefixUriMapper implements UriMapper {
         if (!nodePath.isRoot()) {
             // nodePath is not root, we have to append it to prefix
             uriPath = prefix.append(nodePath.toRelative(Path.ROOT));
+        }
+
+        if(nodePath.toString().endsWith(SitePlugin.BRIX_INDEX_PAGE)) {
+            final String orgUrl = nodePath.toString();
+            String url = orgUrl.substring(0, orgUrl.length() - SitePlugin.BRIX_INDEX_PAGE.length());
+
+            uriPath = new Path(url);
         }
 
         return uriPath;

--- a/brix-core/src/main/java/org/brixcms/plugin/site/SitePlugin.java
+++ b/brix-core/src/main/java/org/brixcms/plugin/site/SitePlugin.java
@@ -108,6 +108,8 @@ public class SitePlugin implements SessionAwarePlugin {
 
     private static final String WEBDAV_RULES_NODE_NAME = Brix.NS_PREFIX + "webDavRules";
 
+    public static final String BRIX_INDEX_PAGE = "index.brix";
+
     private final Brix brix;
 
     private FallbackNodePlugin fallbackNodePlugin = new FallbackNodePlugin();

--- a/brix-core/src/main/java/org/brixcms/web/BrixRequestMapper.java
+++ b/brix-core/src/main/java/org/brixcms/web/BrixRequestMapper.java
@@ -112,6 +112,11 @@ public class BrixRequestMapper extends AbstractComponentMapper {
 
         Path path = new Path("/" + url.getPath());
 
+        //fix for ROOT AJAX requests...-> to index.brix
+        if(path.isRoot() && ((WebRequest)request).isAjax()) {
+            path = new Path("/" + SitePlugin.BRIX_INDEX_PAGE);
+        }
+
         // root path handling
         if (path.isRoot()) {
             final BrixNode node = getNodeForUriPath(path);

--- a/brix-core/src/main/java/org/brixcms/web/BrixRequestMapper.java
+++ b/brix-core/src/main/java/org/brixcms/web/BrixRequestMapper.java
@@ -46,6 +46,7 @@ import org.apache.wicket.request.Url;
 import org.apache.wicket.request.Url.QueryParameter;
 import org.apache.wicket.request.component.IRequestablePage;
 import org.apache.wicket.request.http.WebRequest;
+import org.apache.wicket.request.http.handler.RedirectRequestHandler;
 import org.apache.wicket.request.mapper.info.ComponentInfo;
 import org.apache.wicket.request.mapper.info.PageComponentInfo;
 import org.apache.wicket.request.mapper.info.PageInfo;
@@ -101,6 +102,12 @@ public class BrixRequestMapper extends AbstractComponentMapper {
             if (url.getSegments().get(0).equals("webdav") || url.getSegments().get(0).equals("jcrwebdav")) {
                 return null;
             }
+        }
+
+        // index.brix handling
+        if (url.toString().endsWith(SitePlugin.BRIX_INDEX_PAGE)) {
+            url.getSegments().remove(SitePlugin.BRIX_INDEX_PAGE);
+            return new RedirectRequestHandler("/" + url.getPath());
         }
 
         Path path = new Path("/" + url.getPath());
@@ -305,6 +312,7 @@ public class BrixRequestMapper extends AbstractComponentMapper {
                 PageComponentInfo info = new PageComponentInfo(i, null);
                 Url url = encode(page);
                 encodePageComponentInfo(url, info);
+                url.getSegments().remove(SitePlugin.BRIX_INDEX_PAGE);
                 return url;
             } else {
                 return null;
@@ -371,13 +379,13 @@ public class BrixRequestMapper extends AbstractComponentMapper {
     private Url encode(String nodeURL, PageParameters parameters, PageInfo info) {
         StringBuilder builder = new StringBuilder();
 
-        if (nodeURL.startsWith("/")) {
+        if (nodeURL.startsWith("/") && nodeURL.length() > 1) {
             nodeURL = nodeURL.substring(1);
         }
 
         builder.append(urlEncodePath(new Path(nodeURL, false)));
 
-        boolean skipFirstSlash = builder.charAt(builder.length() - 1) == '/';
+        boolean skipFirstSlash = builder.length() > 1 && builder.charAt(builder.length() - 1) == '/';
 
         for (int i = 0; i < parameters.getIndexedCount(); ++i) {
             if (!skipFirstSlash) {


### PR DESCRIPTION
solves issue #184 from brix

Features: 
- can have any page directly rendered under root or any folder node as long as its called "index.brix"
- works on root and subpaths
- links get rewritten e.g.: /index.brix in a reference will render as / but still have the /index.brix link in the reference itself so the JCR integrity is cared for
- redirects from any index.brix page to its root is done by a 302 at the moment; postponing the possibility of chosing if either 301 or 302 to a later issue
- ajax works in subpath as well as root