### PR TITLE
Removed 'backward compatibility hack'

### DIFF
--- a/brix-core/src/main/java/org/brixcms/plugin/site/page/tile/Tile.java
+++ b/brix-core/src/main/java/org/brixcms/plugin/site/page/tile/Tile.java
@@ -47,10 +47,7 @@ public interface Tile {
         }
 
         public String getUuid() {
-            String tileUuid = Tile.class.getName();
-            //hackish-fix for backward-compatibility required!!!
-            //TODO: better solutions?
-            return tileUuid.replace("org.brixcms.", "brix.");
+            return Tile.class.getName();
         }
     };
 
@@ -109,10 +106,6 @@ public interface Tile {
         }
 
         public static Tile getTileOfType(String type, Brix brix) {
-            //hackish-fix for backward-compatibility required!!!
-            //TODO: better solutions?
-            type = type.replace("org.brixcms.", "brix.");
-
             for (Tile t : getTiles(brix)) {
                 if (t.getTypeName().equals(type)) {
                     return t;

--- a/brix-plugin-menu/src/main/java/org/brixcms/plugin/menu/MenuPlugin.java
+++ b/brix-plugin-menu/src/main/java/org/brixcms/plugin/menu/MenuPlugin.java
@@ -19,10 +19,12 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.ResourceModel;
 import org.brixcms.Brix;
 import org.brixcms.Plugin;
+import org.brixcms.auth.Action;
 import org.brixcms.jcr.JcrNodeWrapperFactory;
 import org.brixcms.jcr.api.JcrNodeIterator;
 import org.brixcms.jcr.api.JcrSession;
 import org.brixcms.jcr.wrapper.BrixNode;
+import org.brixcms.plugin.menu.auth.AccessMenuPluginAction;
 import org.brixcms.plugin.menu.tile.fulltree.FullTreeMenuTile;
 import org.brixcms.plugin.menu.tile.subtree.SubTreeMenuTile;
 import org.brixcms.plugin.site.page.tile.Tile;
@@ -62,27 +64,33 @@ public class MenuPlugin implements Plugin {
 //    private static final String ID = "brix.plugin.menu.MenuPlugin";
 
 
+    @Override
     public String getId() {
 //		System.out.print(ID);
         return ID;
     }
 
+    @Override
     public String getUserVisibleName(Workspace workspace, boolean isFrontend) {
         return null;
     }
 
+    @Override
     public List<Workspace> getWorkspaces(Workspace currentWorkspace, boolean isFrontend) {
         return null;
     }
 
+    @Override
     public void initWorkspace(Workspace workspace, JcrSession workspaceSession) {
 
     }
 
+    @Override
     public boolean isPluginWorkspace(Workspace workspace) {
         return false;
     }
 
+    @Override
     public List<IBrixTab> newTabs(final IModel<Workspace> workspaceModel) {
         IBrixTab tabs[] = new IBrixTab[]{new Tab(new ResourceModel("menus", "Menus"),
                 workspaceModel)};
@@ -142,6 +150,12 @@ public class MenuPlugin implements Plugin {
         @Override
         public Panel newPanel(String panelId, IModel<Workspace> workspaceModel) {
             return new ManageMenuPanel(panelId, workspaceModel);
+        }
+        
+        @Override
+        public boolean isVisible() {
+            final Action action = new AccessMenuPluginAction(getWorkspaceModel().getObject());
+            return Brix.get().getAuthorizationStrategy().isActionAuthorized(action);
         }
     }
 }

--- a/brix-plugin-menu/src/main/java/org/brixcms/plugin/menu/auth/AccessMenuPluginAction.java
+++ b/brix-plugin-menu/src/main/java/org/brixcms/plugin/menu/auth/AccessMenuPluginAction.java
@@ -1,0 +1,26 @@
+package org.brixcms.plugin.menu.auth;
+
+import org.brixcms.auth.Action;
+import org.brixcms.workspace.Workspace;
+
+public class AccessMenuPluginAction implements Action {
+    private final Workspace workspace;
+
+    public AccessMenuPluginAction(Workspace workspace) {
+        this.workspace = workspace;
+    }
+
+    public Workspace getWorkspace() {
+        return workspace;
+    }
+
+    @Override
+    public String toString() {
+        return "AccessMenuPluginAction{" + "workspace=" + workspace + '}';
+    }
+
+    @Override
+    public Context getContext() {
+        return Context.ADMINISTRATION;
+    }
+}


### PR DESCRIPTION
This hack caused that tiles whose type starts on "org.brixcms" (e.g. PageTile) are replaced by Unknown tile. 