### PR TITLE
- fix so that modeshape and jackrabbit both work with the repository;…

### DIFF
--- a/brix-core/src/main/java/org/brixcms/jcr/RepositoryUtil.java
+++ b/brix-core/src/main/java/org/brixcms/jcr/RepositoryUtil.java
@@ -66,7 +66,7 @@ public class RepositoryUtil {
 
                 String type;
                 //todo: find a version that satisfies jackrabbit and modeshape as well
-                if(manager.getClass().toString().contains("jackrabbit")) {
+                if(manager.getClass().getName().contains("jackrabbit")) {
                     type  = "[" + typeName + "] > nt:unstructured ";
                 } else {
                     type  = "[" + typeName + "] > brix:unstructured ";

--- a/brix-core/src/main/java/org/brixcms/jcr/RepositoryUtil.java
+++ b/brix-core/src/main/java/org/brixcms/jcr/RepositoryUtil.java
@@ -64,7 +64,14 @@ public class RepositoryUtil {
                 logger.info("Registering node type: {} in workspace {}", typeName, workspace
                         .getName());
 
-                String type = "[" + typeName + "] > brix:unstructured ";
+                String type;
+                //todo: find a version that satisfies jackrabbit and modeshape as well
+                if(manager.getClass().toString().contains("jackrabbit")) {
+                    type  = "[" + typeName + "] > nt:unstructured ";
+                } else {
+                    type  = "[" + typeName + "] > brix:unstructured ";
+                }
+
 
                 if (referenceable) {
                     type += ", mix:referenceable ";

--- a/brix-core/src/main/java/org/brixcms/markup/web/BrixMarkupNodePanel.java
+++ b/brix-core/src/main/java/org/brixcms/markup/web/BrixMarkupNodePanel.java
@@ -58,9 +58,9 @@ public abstract class BrixMarkupNodePanel extends BrixGenericPanel<BrixNode> imp
     }
 
     @Override
-    protected void onBeforeRender() {
+    protected void onInitialize() {
         this.markupHelper = new MarkupHelper(this);
-        super.onBeforeRender();
+        super.onInitialize();
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 		<jetty.version>9.4.2.v20170220</jetty.version>
 		<inmethod.grid.version>8.0.0-SNAPSHOT</inmethod.grid.version>
 		<htmllexer.version>2.1</htmllexer.version>
-		<jackrabbit.version>2.6.5</jackrabbit.version>
+		<jackrabbit.version>2.14.2</jackrabbit.version>
 		<servlet-api.version>3.1.0</servlet-api.version>
 	</properties>
 


### PR DESCRIPTION
… somehow both refer the same specification, yet behave differently in terms of nt:unstructured/ mixins; Jackrabbit calls an ambigous definition even both definitions (brix:unstructured) and nt:unstructured are same; Yes, modeshape expects it to be added as mixins and not derived from the base node...

this fix is for making it temporarely work with both jackrabbit as well as modeshape; I will try to resolve it on a clean way in the upcoming weeks till brix 8.0 release;