### PR TITLE
fix to mapRequest

### DIFF
--- a/brix-core/src/main/java/org/brixcms/plugin/site/resource/ResourceNodeHandler.java
+++ b/brix-core/src/main/java/org/brixcms/plugin/site/resource/ResourceNodeHandler.java
@@ -100,6 +100,7 @@ public class ResourceNodeHandler implements IRequestHandler {
 			String fileName = node.getName();
 			long length = node.getContentLength();
 			HttpServletResponse httpServletResponse = (HttpServletResponse) response.getContainerResponse();
+			httpServletResponse.setContentType(node.getMimeType());
 			InputStream stream = node.getDataAsStream();
 
 			new Streamer(length, stream, fileName, save, r, httpServletResponse).stream();

--- a/brix-core/src/main/java/org/brixcms/web/BrixRequestMapper.java
+++ b/brix-core/src/main/java/org/brixcms/web/BrixRequestMapper.java
@@ -90,7 +90,7 @@ public class BrixRequestMapper extends AbstractComponentMapper {
 
     @Override
     public IRequestHandler mapRequest(Request request) {
-        final Url url = request.getClientUrl();
+        final Url url = request.getUrl();
 
         if (isInternalWicket(request)) {
             return null;


### PR DESCRIPTION
- changed the mapRequest to getUrl from getClientUrl so that Brix feels also responsible for any configured error pages in web.xml; Before brix would ignore any additional error requests as it just became the original URL in getClientUrl