### PR TITLE
three small fixes that are quite big, so please check if this is ok!

### DIFF
--- a/brix-core/src/main/java/org/brixcms/markup/web/BrixMarkupNodeWebPage.java
+++ b/brix-core/src/main/java/org/brixcms/markup/web/BrixMarkupNodeWebPage.java
@@ -63,9 +63,9 @@ public abstract class BrixMarkupNodeWebPage extends BrixNodeWebPage implements I
     }
 
     @Override
-    protected void onBeforeRender() {
+    protected void onInitialize() {
         getMarkupHelper();
-        super.onBeforeRender();
+        super.onInitialize();
     }
 
     @Override

--- a/brix-core/src/main/java/org/brixcms/plugin/site/resource/ResourceNodeHandler.java
+++ b/brix-core/src/main/java/org/brixcms/plugin/site/resource/ResourceNodeHandler.java
@@ -101,6 +101,7 @@ public class ResourceNodeHandler implements IRequestHandler {
 			long length = node.getContentLength();
 			HttpServletResponse httpServletResponse = (HttpServletResponse) response.getContainerResponse();
 			httpServletResponse.setContentType(node.getMimeType());
+			httpServletResponse.setDateHeader("Last-Modified", node.getLastModified().getTime());
 			InputStream stream = node.getDataAsStream();
 
 			new Streamer(length, stream, fileName, save, r, httpServletResponse).stream();

--- a/brix-core/src/main/java/org/brixcms/web/BrixRequestMapper.java
+++ b/brix-core/src/main/java/org/brixcms/web/BrixRequestMapper.java
@@ -197,7 +197,7 @@ public class BrixRequestMapper extends AbstractComponentMapper {
                     @Override
                     public IRequestablePage newPageInstance(Class<? extends IRequestablePage> pageClass, PageParameters pageParameters) {
                         return new PageRenderingPage(new BrixNodeModel(getNodeForUriPath(finalPath)),
-                                new BrixPageParameters(pageParameters));
+                                createBrixPageParams(request.getUrl(), finalPath));
                     }
                 });
                 return new ListenerRequestHandler(provider, componentInfo.getBehaviorId());


### PR DESCRIPTION
@martin-g @dsimko Please review these and maybe check these with your own brix apps ( @dsimko )

- BrixMarkupNodeWebPage: I moved the component building and adding logic from onBeforeRender to onInitialize; this fixes a problem I had where on some special re-renders of pages errors where thrown like "component already existing"
as a side effect this also boosts brix performance of rendering quite much; On a heavy page I've seen increase of rendering speed up to 300%+; It seems as brix was built here for wicket 1.4 and just accepted that the tree was more than once parsed, needless to say that this is quite costly

- PluginSiteResource: resources now get the Last-Modified header; This was always saved in brix and I really don't know why this got not used/ lost for resources as without this header caching in some browsers like FireFox never worked well;

- BrixRequestMapper: I made a fix to it so that the BrixPageParameters always get newly created based on the URL in case of a re-render of page; Before these would end up empty as the parameters came from newPageInstance and this didnt really help us as those where empty (DefaultMapperContext)