### PR TITLE
fix SiteRootNode 500 error

### DIFF
--- a/brix-core/src/main/java/org/brixcms/plugin/site/page/PageRenderingPage.java
+++ b/brix-core/src/main/java/org/brixcms/plugin/site/page/PageRenderingPage.java
@@ -21,6 +21,8 @@ import org.brixcms.markup.title.TitleTransformer;
 import org.brixcms.markup.transform.HeadTransformer;
 import org.brixcms.markup.variable.VariableTransformer;
 import org.brixcms.markup.web.BrixMarkupNodeWebPage;
+import org.brixcms.plugin.site.SiteRootNode;
+import org.brixcms.plugin.site.folder.FolderNode;
 import org.brixcms.web.nodepage.BrixPageParameters;
 import org.brixcms.web.nodepage.toolbar.ToolbarBehavior;
 
@@ -45,6 +47,12 @@ public class PageRenderingPage extends BrixMarkupNodeWebPage {
 
 
     public MarkupSource getMarkupSource() {
+
+        if(getModelObject() instanceof SiteRootNode) {
+            BrixNode targetNode = ((FolderNode) getModelObject()).getRedirectReference().getNodeModel().getObject();
+            setModelObject(targetNode);
+        }
+
         MarkupSource source = new PageMarkupSource((AbstractContainer) getModelObject());
         return transform(source, (AbstractContainer) getModelObject());
     }


### PR DESCRIPTION
- fixes 500 internal error in case a URL with a SiteRootNode gets called that contains some component info and the page itself is cold as it has not yet been created as the session is new