### PR TITLE
wicket 8.2 / surefire workaround

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ derby.log
 **.settings/
 **.DS_Store
 **.tern-project
+**.flattened-pom.xml
 .idea/

--- a/brix-core/pom.xml
+++ b/brix-core/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>org.brixcms</groupId>
 		<artifactId>brix</artifactId>
-		<version>8.0-SNAPSHOT</version>
+		<version>${revision}${changelist}</version>
 	</parent>
 
 	<groupId>org.brixcms</groupId>
 	<artifactId>brix-core</artifactId>
-	<version>8.0-SNAPSHOT</version>
+	<version>${revision}${changelist}</version>
 
 	<packaging>bundle</packaging>
 

--- a/brix-demo/pom.xml
+++ b/brix-demo/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>org.brixcms</groupId>
 		<artifactId>brix</artifactId>
-		<version>8.0-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
 	</parent>
 
 	<groupId>org.brixcms</groupId>
 	<artifactId>brix-demo</artifactId>
-	<version>8.0-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
 
 	<packaging>war</packaging>
 

--- a/brix-jackrabbit-testdeps/pom.xml
+++ b/brix-jackrabbit-testdeps/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>brix</artifactId>
         <groupId>org.brixcms</groupId>
-        <version>8.0-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
     </parent>
 
     <artifactId>brix-jackrabbit-testdeps</artifactId>

--- a/brix-jackrabbit/pom.xml
+++ b/brix-jackrabbit/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>org.brixcms</groupId>
         <artifactId>brix</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
     </parent>
 
     <groupId>org.brixcms</groupId>
     <artifactId>brix-jackrabbit</artifactId>
-    <version>8.0-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
 
     <name>Brix Jackrabbit Module</name>
     <description>

--- a/brix-modeshape/pom.xml
+++ b/brix-modeshape/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>org.brixcms</groupId>
         <artifactId>brix</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
     </parent>
 
     <groupId>org.brixcms</groupId>
     <artifactId>brix-modeshape</artifactId>
-    <version>8.0-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
 
     <name>Brix ModeShape Module</name>
     <description>

--- a/brix-plugin-menu/pom.xml
+++ b/brix-plugin-menu/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.brixcms</groupId>
         <artifactId>brix</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
     </parent>
 
     <groupId>org.brixcms</groupId>
     <artifactId>brix-plugin-menu</artifactId>
-    <version>8.0-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
 
     <packaging>bundle</packaging>
 
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.brixcms</groupId>
             <artifactId>brix-core</artifactId>
-            <version>8.0-SNAPSHOT</version>
+            <version>${revision}${changelist}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/brix-plugin-prototype/pom.xml
+++ b/brix-plugin-prototype/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.brixcms</groupId>
         <artifactId>brix</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
     </parent>
 
     <groupId>org.brixcms</groupId>
     <artifactId>brix-plugin-prototype</artifactId>
-    <version>8.0-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
 
     <packaging>bundle</packaging>
 
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.brixcms</groupId>
             <artifactId>brix-core</artifactId>
-            <version>8.0-SNAPSHOT</version>
+            <version>${revision}${changelist}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/brix-plugin-publish/pom.xml
+++ b/brix-plugin-publish/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.brixcms</groupId>
         <artifactId>brix</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
     </parent>
 
     <groupId>org.brixcms</groupId>
     <artifactId>brix-plugin-publish</artifactId>
-    <version>8.0-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
 
     <packaging>bundle</packaging>
 
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.brixcms</groupId>
             <artifactId>brix-core</artifactId>
-            <version>8.0-SNAPSHOT</version>
+            <version>${revision}${changelist}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/brix-plugin-snapshot/pom.xml
+++ b/brix-plugin-snapshot/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.brixcms</groupId>
         <artifactId>brix</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
     </parent>
 
     <groupId>org.brixcms</groupId>
     <artifactId>brix-plugin-snapshot</artifactId>
-    <version>8.0-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
 
     <packaging>bundle</packaging>
 
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.brixcms</groupId>
             <artifactId>brix-core</artifactId>
-            <version>8.0-SNAPSHOT</version>
+            <version>${revision}${changelist}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/brix-plugin-webdavurl/pom.xml
+++ b/brix-plugin-webdavurl/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.brixcms</groupId>
         <artifactId>brix</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
     </parent>
 
     <groupId>org.brixcms</groupId>
     <artifactId>brix-plugin-webdavurl</artifactId>
-    <version>8.0-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
 
     <packaging>bundle</packaging>
 
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.brixcms</groupId>
             <artifactId>brix-core</artifactId>
-            <version>8.0-SNAPSHOT</version>
+            <version>${revision}${changelist}</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/brix-rmiserver/pom.xml
+++ b/brix-rmiserver/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.brixcms</groupId>
         <artifactId>brix</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
     </parent>
 
     <groupId>org.brixcms</groupId>
     <artifactId>brix-rmiserver</artifactId>
-    <version>8.0-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
 
     <packaging>war</packaging>
 

--- a/brix-workspace/pom.xml
+++ b/brix-workspace/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <groupId>org.brixcms</groupId>
         <artifactId>brix</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
     </parent>
 
     <groupId>org.brixcms</groupId>
     <artifactId>brix-workspace</artifactId>
-    <version>8.0-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
 
     <packaging>bundle</packaging>
 

--- a/brix-wrapper/pom.xml
+++ b/brix-wrapper/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.brixcms</groupId>
         <artifactId>brix</artifactId>
-        <version>8.0-SNAPSHOT</version>
+        <version>${revision}${changelist}</version>
     </parent>
 
     <groupId>org.brixcms</groupId>
     <artifactId>brix-wrapper</artifactId>
-    <version>8.0-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
 
     <packaging>bundle</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,8 @@
 
 	<groupId>org.brixcms</groupId>
 	<artifactId>brix</artifactId>
-	<version>8.0-SNAPSHOT</version>
+	<!-- works from maven 3.5 on, we now declare the version centrally in properties revision + changelist -->
+	<version>${revision}${changelist}</version>
 
 	<packaging>pom</packaging>
 
@@ -49,6 +50,10 @@
 	</modules>
 
 	<properties>
+		<!-- brix version is now set here -->
+		<revision>8.0.0</revision>
+		<changelist>-SNAPSHOT</changelist>
+
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 
@@ -73,62 +78,62 @@
 			<dependency>
 				<groupId>org.brixcms</groupId>
 				<artifactId>brix-wrapper</artifactId>
-				<version>8.0-SNAPSHOT</version>
+				<version>${revision}${changelist}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.brixcms</groupId>
 				<artifactId>brix-core</artifactId>
-				<version>8.0-SNAPSHOT</version>
+				<version>${revision}${changelist}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.brixcms</groupId>
 				<artifactId>brix-rmiserver</artifactId>
-				<version>8.0-SNAPSHOT</version>
+				<version>${revision}${changelist}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.brixcms</groupId>
 				<artifactId>brix-workspace</artifactId>
-				<version>8.0-SNAPSHOT</version>
+				<version>${revision}${changelist}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.brixcms</groupId>
 				<artifactId>brix-plugin-snapshot</artifactId>
-				<version>8.0-SNAPSHOT</version>
+				<version>${revision}${changelist}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.brixcms</groupId>
 				<artifactId>brix-plugin-prototype</artifactId>
-				<version>8.0-SNAPSHOT</version>
+				<version>${revision}${changelist}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.brixcms</groupId>
 				<artifactId>brix-plugin-menu</artifactId>
-				<version>8.0-SNAPSHOT</version>
+				<version>${revision}${changelist}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.brixcms</groupId>
 				<artifactId>brix-plugin-webdavurl</artifactId>
-				<version>8.0-SNAPSHOT</version>
+				<version>${revision}${changelist}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.brixcms</groupId>
 				<artifactId>brix-plugin-publish</artifactId>
-				<version>8.0-SNAPSHOT</version>
+				<version>${revision}${changelist}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.brixcms</groupId>
 				<artifactId>brix-jackrabbit</artifactId>
-				<version>8.0-SNAPSHOT</version>
+				<version>${revision}${changelist}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.brixcms</groupId>
 				<artifactId>brix-jackrabbit-testdeps</artifactId>
-				<version>8.0-SNAPSHOT</version>
+				<version>${revision}${changelist}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.brixcms</groupId>
 				<artifactId>brix-modeshape</artifactId>
-				<version>8.0-SNAPSHOT</version>
+				<version>${revision}${changelist}</version>
 			</dependency>
 
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 	<properties>
 		<!-- brix version is now set here -->
 		<revision>8.0.0</revision>
-		<changelist>-SNAPSHOTXY</changelist>
+		<changelist>-SNAPSHOT</changelist>
 
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 	<properties>
 		<!-- brix version is now set here -->
 		<revision>8.0.0</revision>
-		<changelist>-SNAPSHOT</changelist>
+		<changelist>-SNAPSHOTXY</changelist>
 
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
@@ -391,6 +391,30 @@
 			</testResource>
 		</testResources>
 		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<version>1.0.1</version>
+				<configuration>
+					<updatePomFile>true</updatePomFile>
+				</configuration>
+				<executions>
+					<execution>
+						<id>flatten</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>flatten</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>flatten.clean</id>
+						<phase>clean</phase>
+						<goals>
+							<goal>clean</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
 		<deployment.disabled>false</deployment.disabled>
 		<sources.disabled>false</sources.disabled>
 
-		<wicket.version>8.0.0</wicket.version>
-		<inmethod.grid.version>8.0.0</inmethod.grid.version>
+		<wicket.version>8.2.0</wicket.version>
+		<inmethod.grid.version>8.2.0</inmethod.grid.version>
 		<jetty.version>9.4.2.v20170220</jetty.version>
 		<htmllexer.version>2.1</htmllexer.version>
 		<jackrabbit.version>2.14.2</jackrabbit.version>
@@ -536,13 +536,17 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.18.1</version>
+					<version>2.22.1</version>
 					<configuration>
 						<includes>
 							<include>**/*Test.java</include>
 						</includes>
 						<testFailureIgnore>false</testFailureIgnore>
 						<argLine>-Xmx1024m</argLine>
+						<!-- needed as a workaround for current surefire-bug under openJDK on debian based systems:
+						reason is backporting of disallowing absolute java paths in OpenJDK by debian team
+						should be fixed by version 3.0.0 version of surefire plugin that is not yet released-->
+						<useSystemClassLoader>false</useSystemClassLoader>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
- upgrade to wicket 8.2.0
- upgrade to inmethod grid 8.2.0
- added workaround for surefire failing on current openJDK (debian based linux systems)